### PR TITLE
[fix] fix to bug on StackedLine.getColor

### DIFF
--- a/ExtHoloGraphLibrary/src/hm/orz/octworks/extholographlibrary/StackedLine.java
+++ b/ExtHoloGraphLibrary/src/hm/orz/octworks/extholographlibrary/StackedLine.java
@@ -4,13 +4,19 @@ import java.util.ArrayList;
 import java.util.Stack;
 
 public class StackedLine {
+    private static final int DEFAULT_COLOR = 0xffffff;
+
     private ArrayList<StackedLinePoint> points = new ArrayList<StackedLinePoint>();
     private ArrayList<Integer> colors = new ArrayList<Integer>();
     private boolean showPoints = true;
 
 
     public Integer getColor(int indexOfLine) {
-        return colors.get(indexOfLine);
+        try {
+            return colors.get(indexOfLine);
+        } catch (IndexOutOfBoundsException e) {
+            return DEFAULT_COLOR;
+        }
     }
 
     public void setColor(int indexOfLine, int color) {


### PR DESCRIPTION
if color isn't set, StackedLine.getColor throw IndexOutOfBoundsException.
so modified then return default color.
